### PR TITLE
add missing abi to VaultFactory dataSource

### DIFF
--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -37,6 +37,8 @@ dataSources:
       abis:
         - name: InstanceRegistry
           file: ./abis/IInstanceRegistry.json
+        - name: VaultContract
+          file: ./abis/IUniversalVault.json
       eventHandlers:
         - event: InstanceAdded(address)
           handler: handleNewVault


### PR DESCRIPTION
## Description

The `updateVault` function in `subgraph/src/vault.ts` uses `VaultContract`. Without specifying the abi of `VaultContract` in `VaultFactory`, the subgraph will fail to handle vault creation