### PR TITLE
create and withdraw fix

### DIFF
--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -32,9 +32,9 @@ export const create = async (signer: Signer) => {
     signer,
   )
 
-  const vaultAddress = await vaultFactory.callStatic.create()
+  const vaultAddress = await vaultFactory.callStatic['create()']()
 
-  await vaultFactory.create()
+  await vaultFactory['create()']()
 
   const vault = new Contract(vaultAddress, config.VaultTemplate.abi, signer)
 
@@ -118,13 +118,11 @@ export const withdraw = async (
   const vault = new Contract(vaultAddress, config.VaultTemplate.abi, signer)
   const token = new Contract(tokenAddress, ERC20_ABI, signer)
 
-  const calldata = (
-    await token.populateTransaction.transfer(recipientAddress, amount)
-  ).data
-
-  return vault.externalCall([token.address, 0, calldata]) as Promise<
-    TransactionResponse
-  >
+  return vault.transferERC20(
+    token.address,
+    recipientAddress,
+    amount,
+  ) as Promise<TransactionResponse>
 }
 
 /// Combined Actions ///


### PR DESCRIPTION
## Description

For `create`: the key should be "create()" instead of "create"

For `withdraw`: `externalCall` was replaced with `transferERC20` in https://github.com/ampleforth/token-geyser-v2/pull/193/files#diff-b838c6f4829d8bf6ca7077cf3c754797746c5ae697d7c6ccd19952a6b9887ccaR893-R895 