### PR TITLE
Put geyser, rewardTokenInfo, and stakingTokenInfo into a single state

### DIFF
--- a/frontend/src/components/GeyserFirst/EstimatedRewards.tsx
+++ b/frontend/src/components/GeyserFirst/EstimatedRewards.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export const EstimatedRewards: React.FC<Props> = ({ parsedUserInput }) => {
   const [rewards, setRewards] = useState<string>('0.00')
-  const { rewardTokenInfo: { symbol } } = useContext(GeyserContext)
+  const { selectedGeyserInfo: { rewardTokenInfo: { symbol } } } = useContext(GeyserContext)
   const { computeRewardsFromAdditionalStakes, geyserStats: { calcPeriodInDays } } = useContext(StatsContext)
 
   useEffect(() => {

--- a/frontend/src/components/GeyserFirst/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserFirst/GeyserStakeView.tsx
@@ -29,7 +29,7 @@ import {
 export const GeyserStakeView = () => {
   const [userInput, setUserInput] = useState('')
   const [parsedUserInput, setParsedUserInput] = useState(BigNumber.from('0'))
-  const { selectedGeyser, stakingTokenInfo, rewardTokenInfo, handleGeyserAction, isStakingAction } = useContext(GeyserContext)
+  const { selectedGeyserInfo: { geyser: selectedGeyser, stakingTokenInfo, rewardTokenInfo }, handleGeyserAction, isStakingAction } = useContext(GeyserContext)
   const { decimals: stakingTokenDecimals, symbol: stakingTokenSymbol, address: stakingTokenAddress } = stakingTokenInfo
   const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol, address: rewardTokenAddress } = rewardTokenInfo
   const { signer } = useContext(Web3Context)

--- a/frontend/src/components/GeyserFirst/GeyserStats.tsx
+++ b/frontend/src/components/GeyserFirst/GeyserStats.tsx
@@ -10,7 +10,7 @@ import { DAY_IN_SEC } from '../../constants'
 
 export const GeyserStats = () => {
   const { geyserStats: { duration, totalDeposit, totalRewards }} = useContext(StatsContext)
-  const { rewardTokenInfo: { symbol } } = useContext(GeyserContext)
+  const { selectedGeyserInfo: { rewardTokenInfo: { symbol } } } = useContext(GeyserContext)
 
   return (
     <GeyserStatsContainer>

--- a/frontend/src/components/GeyserFirst/MyStats.tsx
+++ b/frontend/src/components/GeyserFirst/MyStats.tsx
@@ -23,8 +23,10 @@ export const MyStats = () => {
     geyserStats: { duration },
   } = useContext(StatsContext)
   const {
-    rewardTokenInfo: { symbol: rewardTokenSymbol },
-    stakingTokenInfo: { price: stakingTokenPrice },
+    selectedGeyserInfo: {
+      rewardTokenInfo: { symbol: rewardTokenSymbol },
+      stakingTokenInfo: { price: stakingTokenPrice },
+    },
   } = useContext(GeyserContext)
 
   const getTooltipMessages = useCallback(

--- a/frontend/src/components/GeyserFirst/UnstakeConfirmModal.tsx
+++ b/frontend/src/components/GeyserFirst/UnstakeConfirmModal.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export const UnstakeConfirmModal: React.FC<Props> = ({ parsedUserInput, open, onClose, onConfirm }) => {
   const { computeLossFromUnstake1Month } = useContext(StatsContext)
-  const { rewardTokenInfo: { symbol }} = useContext(GeyserContext)
+  const { selectedGeyserInfo: { rewardTokenInfo: { symbol } } } = useContext(GeyserContext)
   const [loss, setLoss] = useState<string>('0.00')
 
   useEffect(() => {

--- a/frontend/src/components/GeyserFirst/UnstakeSummary.tsx
+++ b/frontend/src/components/GeyserFirst/UnstakeSummary.tsx
@@ -14,7 +14,12 @@ interface Props {
 }
 
 export const UnstakeSummary: React.FC<Props> = ({ userInput, parsedUserInput }) => {
-  const { rewardTokenInfo: { symbol: rewardTokenSymbol }, stakingTokenInfo: { symbol: stakingTokenSymbol } } = useContext(GeyserContext)
+  const {
+    selectedGeyserInfo: {
+      rewardTokenInfo: { symbol: rewardTokenSymbol },
+      stakingTokenInfo: { symbol: stakingTokenSymbol },
+    },
+  } = useContext(GeyserContext)
   const { computeRewardsFromUnstake } = useContext(StatsContext)
 
   const [rewardAmount, setRewardAmount] = useState<string>('0.00')

--- a/frontend/src/components/GeysersList.tsx
+++ b/frontend/src/components/GeysersList.tsx
@@ -7,7 +7,7 @@ import { GeyserStatus } from 'types'
 import { Dropdown } from './Dropdown'
 
 export const GeysersList = () => {
-  const { geysers, selectGeyserByName, selectedGeyser, getGeyserName } = useContext(GeyserContext)
+  const { geysers, selectGeyserByName, selectedGeyserInfo: { geyser: selectedGeyser }, getGeyserName } = useContext(GeyserContext)
   const handleGeyserChange = (geyserName: string) => selectGeyserByName(geyserName)
 
   const optgroups = (() => {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -21,7 +21,7 @@ export const POLL_INTERVAL = 5 * MS_PER_SEC
 export const CONST_CACHE_TIME_MS = YEAR_IN_MS
 
 // geyser stats cache time
-export const GEYSER_STATS_CACHE_TIME_MS = 0
+export const GEYSER_STATS_CACHE_TIME_MS = MIN_IN_MS
 
 export const MOCK_ERC_20_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F'
 

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -32,7 +32,7 @@ export const VaultContext = createContext<{
 
 export const VaultContextProvider: React.FC = ({ children }) => {
   const { address, signer, ready } = useContext(Web3Context)
-  const { selectedGeyser } = useContext(GeyserContext)
+  const { selectedGeyserInfo: { geyser: selectedGeyser } } = useContext(GeyserContext)
   const [getVaults, { loading: vaultLoading, data: vaultData }] = useLazyQuery(GET_USER_VAULTS, {
     pollInterval: POLL_INTERVAL,
   })

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -15,7 +15,7 @@ export const WalletContext = createContext<{
 export const WalletContextProvider: React.FC = ({ children }) => {
   const [walletAmount, setWalletAmount] = useState<BigNumber>(BigNumber.from('0'))
   const { signer } = useContext(Web3Context)
-  const { selectedGeyser } = useContext(GeyserContext)
+  const { selectedGeyserInfo: { geyser: selectedGeyser } } = useContext(GeyserContext)
 
   const getWalletAmount = useCallback(async () => {
     if (selectedGeyser && signer) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,6 +76,12 @@ export type RewardTokenInfo = TokenInfo & {
   getTotalRewards: (rewardSchedules: RewardSchedule[]) => Promise<number>
 }
 
+export type GeyserInfo = {
+  geyser: Geyser | null
+  stakingTokenInfo: StakingTokenInfo
+  rewardTokenInfo: RewardTokenInfo
+}
+
 export type GeyserStats = {
   duration: number
   totalDeposit: number


### PR DESCRIPTION
## Description

Previously, since states for `selectedGeyser`, `rewardTokenInfo`, and `stakingTokenInfo` were in separate state variables, geyser stats are not computed correctly due to the async nature of state updates and the caching mechanism

The problem:
- Suppose user is viewing `geyser_A` with `rewardTokenInfo_A` and `stakingTokenInfo_A`
- User switches to `geyser_B`, but the updates for reward token and staking token infos are still underway
- Stats are then calculated with `geyser_B`, `rewardTokenInfo_A` and `stakingTokenInfo_A`, and cached
- When the updates for reward token and staking token infos are finally applied, stats calculations are about to be re-computed, but since they are found in cache, the stats in cache are used instead. Which is why setting cache = 0 solves this issue

Solution:
- Have `selectedGeyser`, `rewardTokenInfo` and `stakingTokenInfo` share the same state