### PR TITLE
Fixed user flow issue when LP tokens are stuck in the vault

### DIFF
--- a/frontend/src/components/GeyserFirst/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserFirst/GeyserStakeView.tsx
@@ -35,7 +35,7 @@ export const GeyserStakeView = () => {
   const { signer } = useContext(Web3Context)
   const { selectedVault, currentLock, withdrawFromVault, withdrawRewardsFromVault, withdrawUnlockedFromVault } = useContext(VaultContext)
   const { walletAmount, refreshWalletAmount } = useContext(WalletContext)
-  const { refreshVaultStats } = useContext(StatsContext)
+  const { refreshVaultStats, vaultStats: {currentStakable} } = useContext(StatsContext)
   const { selectWallet, address } = useContext(Web3Context)
   const currentStakeAmount = BigNumber.from(currentLock ? currentLock.amount : '0')
   const [unstakeConfirmModalOpen, setUnstakeConfirmModalOpen] = useState<boolean>(false)
@@ -126,11 +126,13 @@ export const GeyserStakeView = () => {
     <WithdrawTxMessage txStateMachine={txStateMachine} symbol={rewardTokenSymbol} amount={formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} />
   )
 
+  const stakableAmount = walletAmount.add(currentStakable)
+
   return (
     <GeyserStakeViewContainer>
       <UserBalance
         parsedAmount={parsedUserInput}
-        currentAmount={isStakingAction ? walletAmount : currentStakeAmount}
+        currentAmount={isStakingAction ? stakableAmount : currentStakeAmount}
         decimals={stakingTokenDecimals}
         symbol={stakingTokenSymbol}
         isStakingAction={isStakingAction}
@@ -140,7 +142,7 @@ export const GeyserStakeView = () => {
         value={userInput}
         onChange={handleOnChange}
         precision={stakingTokenDecimals}
-        maxValue={isStakingAction ? walletAmount : currentStakeAmount}
+        maxValue={isStakingAction ? stakableAmount : currentStakeAmount}
         skipMaxEnforcement={isStakingAction}
       />
       {isStakingAction ? (

--- a/frontend/src/components/GeyserFirst/MyStats.tsx
+++ b/frontend/src/components/GeyserFirst/MyStats.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from 'components/Tooltip'
 import { GeyserStatsBox } from './GeyserStatsBox'
 import { MyStatsBox } from './MyStatsBox'
 import {
-  DAY_IN_SEC,
   GET_APY_NO_STAKE_MSG,
   GET_APY_STAKE_MSG,
   GET_CURRENT_REWARDS_MSG,
@@ -20,7 +19,7 @@ export const MyStats = () => {
   const {
     userStats: { apy, currentMultiplier, maxMultiplier, currentReward },
     vaultStats: { currentStake },
-    geyserStats: { duration, calcPeriodInDays},
+    geyserStats: { calcPeriodInDays},
   } = useContext(StatsContext)
   const {
     selectedGeyserInfo: {
@@ -33,11 +32,11 @@ export const MyStats = () => {
     () => [
       {
         title: 'APY',
-        body: currentStake > 0 ? GET_APY_STAKE_MSG() : GET_APY_NO_STAKE_MSG({ days: safeNumeral(duration / DAY_IN_SEC, '0.0') }),
+        body: currentStake > 0 ? GET_APY_STAKE_MSG() : GET_APY_NO_STAKE_MSG({ days: safeNumeral(calcPeriodInDays||30, '0.0') }),
       },
       {
         title: 'Reward Multiplier',
-        body: GET_REWARD_MULTIPLIER_MSG({ days: safeNumeral(calcPeriodInDays, '0.0'), multiplier: safeNumeral(maxMultiplier, '0.0') }),
+        body: GET_REWARD_MULTIPLIER_MSG({ days: safeNumeral(calcPeriodInDays||30, '0.0'), multiplier: safeNumeral(maxMultiplier||3, '0.0') }),
       },
       {
         title: 'Current Rewards',

--- a/frontend/src/components/GeyserFirst/UserBalance.tsx
+++ b/frontend/src/components/GeyserFirst/UserBalance.tsx
@@ -16,9 +16,9 @@ export const UserBalance: React.FC<Props> = ({ parsedAmount, currentAmount, deci
   return (
     <FlexDiv>
       {parsedAmount.isZero() ? (
-        <Text>{isStakingAction ? 'Wallet' : 'Staked'} balance: {formatDisplayAmount(currentAmount)} ({symbol})</Text>
+        <Text>{isStakingAction ? 'Stakable' : 'Staked'} balance: {formatDisplayAmount(currentAmount)} ({symbol})</Text>
       ) : (
-        <Text>New {isStakingAction ? 'wallet' : 'stake'} balance: {formatDisplayAmount(currentAmount.sub(parsedAmount))} ({symbol})</Text>
+        <Text>New {isStakingAction ? 'stakable' : 'stake'} balance: {formatDisplayAmount(currentAmount.sub(parsedAmount))} ({symbol})</Text>
       )}
     </FlexDiv>
   )

--- a/frontend/src/components/GeysersList.tsx
+++ b/frontend/src/components/GeysersList.tsx
@@ -11,6 +11,8 @@ export const GeysersList = () => {
   const handleGeyserChange = (geyserName: string) => selectGeyserByName(geyserName)
 
   const optgroups = (() => {
+    // NOTE: active inactive logic is wrong
+    // FIX ME!
     const activeGeysers = geysers
       .filter(({ status }) => status !== GeyserStatus.SHUTDOWN)
       .map(({ id }) => getGeyserName(id))

--- a/frontend/src/components/SingleTxMessage.tsx
+++ b/frontend/src/components/SingleTxMessage.tsx
@@ -12,7 +12,7 @@ export const SingleTxMessage: React.FC<Props> = ({ txStateMachine: { state, resp
   const getTxMessage = () => {
     switch(state) {
       case TxState.PENDING:
-        return <span>Waiting for user to confirm transaction...</span>
+        return <span>Waiting for transaction confirmation...</span>
       case TxState.SUBMITTED:
         return (
           <span>

--- a/frontend/src/components/VaultFirst/VaultBalanceView.tsx
+++ b/frontend/src/components/VaultFirst/VaultBalanceView.tsx
@@ -69,8 +69,8 @@ export const VaultBalanceView = () => {
       ({
         key: vaultTokenBalance.symbol,
         token: <TextEllipsis>{vaultTokenBalance.symbol}</TextEllipsis>,
-        balance: safeNumeral(vaultTokenBalance.balance, '0.00'),
-        unlocked: safeNumeral(vaultTokenBalance.unlockedBalance, '0.00'),
+        balance: safeNumeral(vaultTokenBalance.balance, '0.00000'),
+        unlocked: safeNumeral(vaultTokenBalance.unlockedBalance, '0.00000'),
         action: (
           <ActionButton
             disabled={vaultTokenBalance.parsedUnlockedBalance.isZero()}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -102,7 +102,7 @@ export enum Align {
 export const ALCHEMY_PROJECT_ID = 'geo5oyrZyF7LWPaAt7eoLzxHg76ljgsO'
 
 // Infura
-export const INFURA_PROJECT_ID = 'dee1a87a734042fcabc2fd116a7b776d'
+export const INFURA_PROJECT_ID = ''
 
 // Enable withdrawing whole unlocked balance of staking tokens when unstaking
 export const WITHDRAW_UNLOCKED_STAKING_TOKENS_WHEN_UNSTAKING = false

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -15,7 +15,7 @@ export const MONTH_IN_MS = MONTH_IN_SEC * MS_PER_SEC
 export const YEAR_IN_MS = YEAR_IN_SEC * MS_PER_SEC
 
 // polling interval for querying subgraph
-export const POLL_INTERVAL = 5 * MS_PER_SEC
+export const POLL_INTERVAL = 30 * MS_PER_SEC
 
 // pseudo permanent cache time
 export const CONST_CACHE_TIME_MS = YEAR_IN_MS

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -89,7 +89,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
   const refreshVaultStats = async () => {
     const { geyser: selectedGeyser, stakingTokenInfo, rewardTokenInfo } = selectedGeyserInfo
     if (selectedGeyser && stakingTokenInfo.address && rewardTokenInfo.address) {
-      setVaultStats(await getVaultStats(stakingTokenInfo, rewardTokenInfo, allTokensInfos, selectedVault, currentLock, signer || defaultProvider))
+      setVaultStats(await getVaultStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo, allTokensInfos, selectedVault, currentLock, signer || defaultProvider))
     }
   }
 
@@ -101,7 +101,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
         if (selectedGeyser && stakingTokenInfo.address && rewardTokenInfo.address) {
           const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo)
           const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer || defaultProvider)
-          const newVaultStats = await getVaultStats(stakingTokenInfo, rewardTokenInfo, allTokensInfos, selectedVault, currentLock, signer || defaultProvider)
+          const newVaultStats = await getVaultStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo, allTokensInfos, selectedVault, currentLock, signer || defaultProvider)
           if (mounted) {
             setGeyserStats(newGeyserStats)
             setUserStats(newUserStats)

--- a/frontend/src/queries/vault.ts
+++ b/frontend/src/queries/vault.ts
@@ -14,6 +14,9 @@ export const GET_USER_VAULTS = gql`
         }
         locks(first: 1000) {
           id
+          geyser {
+            id
+          }
           token
           amount
           stakeUnits

--- a/frontend/src/queries/vault.ts
+++ b/frontend/src/queries/vault.ts
@@ -14,9 +14,6 @@ export const GET_USER_VAULTS = gql`
         }
         locks(first: 1000) {
           id
-          geyser {
-            id
-          }
           token
           amount
           stakeUnits

--- a/frontend/src/sdk/actions.ts
+++ b/frontend/src/sdk/actions.ts
@@ -154,14 +154,7 @@ export const approveDepositStake = async (
   const vault = new Contract(vaultAddress, config.VaultTemplate.abi, signer)
 
   // calculate stakable balance in the vault
-  let stakableAmountInVault = await token.balanceOf(vault.address)
-  const nLocks = await vault.getLockSetCount()
-  for (let i = 0; i < nLocks.toNumber(); i++) {
-    const lock = await vault.getLockAt(i)
-    if (toChecksumAddress(lock.delegate) === toChecksumAddress(geyserAddress)) {
-      stakableAmountInVault = stakableAmountInVault.sub(lock.balance)
-    }
-  }
+  let stakableAmountInVault = (await token.balanceOf(vault.address)).sub(await vault.getBalanceDelegated(token.address, geyser.address))
 
   // The remaining amount gets transferred from the user's wallet to the vault
   const remainingAmountToTransfer = BigNumber.from(amountToStake).sub(stakableAmountInVault)

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -25,9 +25,9 @@ async function _execVaultFunction<T>(
   return vault[fnc](...args) as Promise<T>
 }
 
-export const getVaultData = async (
-  vaultAddress: string,
+export const getGeyserVaultData = async (
   geyserAddress: string,
+  vaultAddress: string,
   signerOrProvider: Signer | providers.Provider,
 ) => {
   return _execGeyserFunction<VaultData>(geyserAddress, signerOrProvider, 'getVaultData', [vaultAddress])

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -102,6 +102,7 @@ export type VaultStats = {
   rewardTokenBalance: number
   vaultTokenBalances: VaultTokenBalance[]
   currentStake: number
+  currentStakable: BigNumber
 }
 
 export type UserStats = {

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -49,6 +49,7 @@ export const defaultVaultStats = (): VaultStats => ({
   rewardTokenBalance: 0,
   vaultTokenBalances: [],
   currentStake: 0,
+  currentStakable: BigNumber.from('0'),
 })
 
 const getGeyserDuration = (geyser: Geyser) => {
@@ -196,8 +197,8 @@ export const getUserAPY = async (
     .add(lock ? lock.amount : '0')
     .toString()
 
-  const inflow = parseFloat(stakedAmount) / 10 ** stakingTokenDecimals * stakingTokenPrice
-  const outflow = Math.round(drip) / 10 ** rewardTokenDecimals * rewardTokenPrice
+  const inflow = (parseFloat(stakedAmount) / 10 ** stakingTokenDecimals) * stakingTokenPrice
+  const outflow = (Math.round(drip) / 10 ** rewardTokenDecimals) * rewardTokenPrice
   const periods = YEAR_IN_SEC / calcPeriod
   return calculateAPY(inflow, outflow, periods)
 }
@@ -346,7 +347,6 @@ export const getVaultStats = async (
 ): Promise<VaultStats> => {
   if (!vault) return defaultVaultStats()
   const vaultAddress = toChecksumAddress(vault.id)
-  const geyserAddress = toChecksumAddress(geyser.id)
 
   const addressSet = new Set<string>([stakingTokenInfo.address, rewardTokenInfo.address].map(toChecksumAddress))
   const stakingTokenBalanceInfo = await getVaultTokenBalance(stakingTokenInfo, vaultAddress, signerOrProvider)
@@ -373,6 +373,7 @@ export const getVaultStats = async (
 
   const amount = lock ? lock.amount : '0'
   const currentStake = parseFloat(formatUnits(amount, stakingTokenInfo.decimals))
+  const currentStakable = stakingTokenBalanceInfo.parsedBalance.sub(amount)
 
   return {
     id: vaultAddress,
@@ -380,5 +381,6 @@ export const getVaultStats = async (
     rewardTokenBalance: rewardTokenBalanceInfo.balance,
     vaultTokenBalances,
     currentStake,
+    currentStakable,
   }
 }

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -273,7 +273,7 @@ const getCurrentMultiplier = async (
     const amt = parseFloat(stake.amount.toString())
     const ts = parseFloat(stake.timestamp.toString())
     const perc = Math.min(now - ts, st) / st
-    weightedStake = perc * amt
+    weightedStake += perc * amt
   })
   const fraction = weightedStake / totalStake
 

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -2,7 +2,7 @@ import { BigNumber, BigNumberish } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
 import { formatUnits } from 'ethers/lib/utils'
 import {
-  getVaultData,
+  getGeyserVaultData,
   getBalanceLocked,
   getCurrentUnlockedRewards,
   getCurrentVaultReward,
@@ -263,11 +263,12 @@ const getCurrentMultiplier = async (
   const minMultiplier = 1
   const maxMultiplier = parseInt(scalingCeiling, 10) / parseInt(scalingFloor, 10)
 
-  const vaultData = await getVaultData(vaultAddress, geyserAddress, signerOrProvider)
-  const totalStake = parseFloat(vaultData.totalStake.toString())
+  // TODO: can we fetch this from the subgraph?
+  const geyserVaultData = await getGeyserVaultData(geyserAddress, vaultAddress, signerOrProvider)
+  const totalStake = parseFloat(geyserVaultData.totalStake.toString())
   const st = parseFloat(scalingTime.toString())
   let weightedStake = 0
-  vaultData.stakes.forEach((stake) => {
+  geyserVaultData.stakes.forEach((stake) => {
     const amt = parseFloat(stake.amount.toString())
     const ts = parseFloat(stake.timestamp.toString())
     const perc = Math.min(now - ts, st) / st
@@ -335,6 +336,7 @@ const getVaultTokenBalance = async (
 }
 
 export const getVaultStats = async (
+  geyser: Geyser,
   stakingTokenInfo: StakingTokenInfo,
   rewardTokenInfo: RewardTokenInfo,
   allTokensInfos: TokenInfo[],
@@ -344,6 +346,7 @@ export const getVaultStats = async (
 ): Promise<VaultStats> => {
   if (!vault) return defaultVaultStats()
   const vaultAddress = toChecksumAddress(vault.id)
+  const geyserAddress = toChecksumAddress(geyser.id)
 
   const addressSet = new Set<string>([stakingTokenInfo.address, rewardTokenInfo.address].map(toChecksumAddress))
   const stakingTokenBalanceInfo = await getVaultTokenBalance(stakingTokenInfo, vaultAddress, signerOrProvider)


### PR DESCRIPTION
Fixed user flow issue when LP tokens are stuck in the vault and the user can't deposit them. Currently, the user has the withdraw it back to his wallet and then attempt to deposit

Modified the sdk such that the deposit function first looks for unlocked LP tokens in the user's vault and locks them before looking at the user's wallet ..